### PR TITLE
upgrade to react-admin 3.0 format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1211,6 +1211,11 @@
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
+    "lodash.omitby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.omitby/-/lodash.omitby-4.6.0.tgz",
+      "integrity": "sha1-XBX/R1StVVAWtTwEExHo8HkgR5E="
+    },
     "magic-string": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "homepage": "https://github.com/FusionWorks/react-admin-nestjsx-crud-dataprovider#readme",
   "dependencies": {
-    "@nestjsx/crud-request": "^4.1.0"
+    "@nestjsx/crud-request": "^4.1.0",
+    "lodash.omitby": "^4.6.0"
   },
   "peerDependencies": {
     "react-admin": "^2.8.5"

--- a/src/index.js
+++ b/src/index.js
@@ -1,169 +1,134 @@
 import { RequestQueryBuilder, CondOperator } from '@nestjsx/crud-request';
-import {
-  fetchUtils,
-  GET_LIST,
-  GET_ONE,
-  GET_MANY,
-  GET_MANY_REFERENCE,
-  CREATE,
-  UPDATE,
-  UPDATE_MANY,
-  DELETE,
-  DELETE_MANY,
-} from 'react-admin';
+import omitBy from 'lodash.omitby';
+import { fetchUtils } from 'react-admin';
 
-export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
-  const composeFilter = (paramsFilter) => {
+const countDiff = (o1, o2) =>
+  omitBy(o1, (v, k) => o2[k] === v);
 
-    if (paramsFilter === '' || (typeof paramsFilter.q !== 'undefined' && paramsFilter.q === '')) {
-      paramsFilter = {}
+const composeFilter = (paramsFilter) => {
+  if (paramsFilter === '' || (typeof paramsFilter.q !== 'undefined' && paramsFilter.q === '')) {
+    paramsFilter = {};
+  }
+
+  const flatFilter = fetchUtils.flattenObject(paramsFilter);
+  return Object.keys(flatFilter).map((key) => {
+    const splitKey = key.split('||');
+    const ops = splitKey[1] ? splitKey[1] : 'cont';
+    let field = splitKey[0];
+
+    if (field.startsWith('_') && field.includes('.')) {
+      field = field.split(/\.(.+)/)[1];
     }
+    return { field, operator: ops, value: flatFilter[key] };
+  });
+};
 
-    const flatFilter = fetchUtils.flattenObject(paramsFilter);
-    const filter = Object.keys(flatFilter).map(key => {
-      const splitKey = key.split('||');
-      const ops = splitKey[1] ? splitKey[1] : 'cont';
-      let field = splitKey[0];
+export default (apiUrl, httpClient = fetchUtils.fetchJson) => ({
+  getList: (resource, params) => {
+    const { page, perPage } = params.pagination;
 
-      if (field.indexOf('_') === 0 && field.indexOf('.') > -1) {
-        field = field.split(/\.(.+)/)[1];
-      }
-      return { field, operator: ops, value: flatFilter[key] };
+    const query = RequestQueryBuilder.create({
+      filter: composeFilter(params.filter),
+    })
+      .setLimit(perPage)
+      .setPage(page)
+      .sortBy(params.sort)
+      .setOffset((page - 1) * perPage)
+      .query();
+
+    const url = `${apiUrl}/${resource}?${query}`;
+
+    return httpClient(url).then(({ json }) => ({
+      data: json.data,
+      total: json.total,
+    }));
+  },
+
+  getOne: (resource, params) =>
+    httpClient(`${apiUrl}/${resource}/${params.id}`).then(({ json }) => ({
+      data: json,
+    })),
+
+  getMany: (resource, params) => {
+    const query = RequestQueryBuilder.create()
+      .setFilter({
+        field: 'id',
+        operator: CondOperator.IN,
+        value: `${params.ids}`,
+      })
+      .query();
+
+    const url = `${apiUrl}/${resource}?${query}`;
+
+    return httpClient(url).then(({ json }) => ({ data: json }));
+  },
+
+  getManyReference: (resource, params) => {
+    const { page, perPage } = params.pagination;
+    const filter = composeFilter(params.filter);
+
+    filter.push({
+      field: params.target,
+      operator: CondOperator.EQUALS,
+      value: params.id,
     });
-    return filter;
-  };
 
-  const convertDataRequestToHTTP = (type, resource, params) => {
-    let url = '';
-    const options = {};
-    switch (type) {
-      case GET_LIST: {
-        const { page, perPage } = params.pagination;
+    const query = RequestQueryBuilder.create({
+      filter,
+    })
+      .sortBy(params.sort)
+      .setLimit(perPage)
+      .setOffset((page - 1) * perPage)
+      .query();
 
-        const query = RequestQueryBuilder
-          .create({
-            filter: composeFilter(params.filter),
-          })
-          .setLimit(perPage)
-          .setPage(page)
-          .sortBy(params.sort)
-          .setOffset((page - 1) * perPage)
-          .query();
+    const url = `${apiUrl}/${resource}?${query}`;
 
-        url = `${apiUrl}/${resource}?${query}`;
+    return httpClient(url).then(({ json }) => ({
+      data: json.data,
+      total: json.total,
+    }));
+  },
 
-        break;
-      }
-      case GET_ONE: {
-        url = `${apiUrl}/${resource}/${params.id}`;
+  update: (resource, params) => {
+    // no need to send all fields on partial update; only updated fields are enough
+    const data = countDiff(params.data, params.previousData);
+    return httpClient(`${apiUrl}/${resource}/${params.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }).then(({ json }) => ({ data: json }));
+  },
 
-        break;
-      }
-      case GET_MANY: {
-        const query = RequestQueryBuilder
-          .create()
-          .setFilter({
-            field: 'id',
-            operator: CondOperator.IN,
-            value: `${params.ids}`,
-          })
-          .query();
-
-        url = `${apiUrl}/${resource}?${query}`;
-
-        break;
-      }
-      case GET_MANY_REFERENCE: {
-        const { page, perPage } = params.pagination;
-        const filter = composeFilter(params.filter);
-
-        filter.push({
-          field: params.target,
-          operator: CondOperator.EQUALS,
-          value: params.id,
-        });
-
-        const query = RequestQueryBuilder
-          .create({
-            filter,
-          })
-          .sortBy(params.sort)
-          .setLimit(perPage)
-          .setOffset((page - 1) * perPage)
-          .query();
-
-        url = `${apiUrl}/${resource}?${query}`;
-
-        break;
-      }
-      case UPDATE: {
-        url = `${apiUrl}/${resource}/${params.id}`;
-        options.method = 'PATCH';
-        options.body = JSON.stringify(params.data);
-        break;
-      }
-      case CREATE: {
-        url = `${apiUrl}/${resource}`;
-        options.method = 'POST';
-        options.body = JSON.stringify(params.data);
-        break;
-      }
-      case DELETE: {
-        url = `${apiUrl}/${resource}/${params.id}`;
-        options.method = 'DELETE';
-        break;
-      }
-      default:
-        throw new Error(`Unsupported fetch action type ${type}`);
-    }
-    return { url, options };
-  };
-
-  const convertHTTPResponse = (response, type, resource, params) => {
-    const { headers, json } = response;
-    switch (type) {
-      case GET_LIST:
-      case GET_MANY_REFERENCE:
-        return {
-          data: json.data,
-          total: json.total,
-        };
-      case CREATE:
-        return { data: { ...params.data, id: json.id } };
-      default:
-        return { data: json };
-    }
-  };
-
-  return (type, resource, params) => {
-    if (type === UPDATE_MANY) {
-      return Promise.all(
-        params.ids.map(id => httpClient(`${apiUrl}/${resource}/${id}`, {
+  updateMany: (resource, params) =>
+    Promise.all(
+      params.ids.map((id) =>
+        httpClient(`${apiUrl}/${resource}/${id}`, {
           method: 'PUT',
           body: JSON.stringify(params.data),
-        })),
-      )
-        .then(responses => ({
-          data: responses.map(response => response.json),
-        }));
-    }
-    if (type === DELETE_MANY) {
-      return Promise.all(
-        params.ids.map(id => httpClient(`${apiUrl}/${resource}/${id}`, {
-          method: 'DELETE',
-        })),
-      ).then(responses => ({
-        data: responses.map(response => response.json),
-      }));
-    }
+        }),
+      ),
+    ).then((responses) => ({
+      data: responses.map(({ json }) => json),
+    })),
 
-    const { url, options } = convertDataRequestToHTTP(
-      type,
-      resource,
-      params,
-    );
-    return httpClient(url, options).then(
-      response => convertHTTPResponse(response, type, resource, params),
-    );
-  };
-};
+  create: (resource, params) =>
+    httpClient(`${apiUrl}/${resource}`, {
+      method: 'POST',
+      body: JSON.stringify(params.data),
+    }).then(({ json }) => ({
+      data: { ...params.data, id: json.id },
+    })),
+
+  delete: (resource, params) =>
+    httpClient(`${apiUrl}/${resource}/${params.id}`, {
+      method: 'DELETE',
+    }).then(({ json }) => ({ data: json })),
+
+  deleteMany: (resource, params) =>
+    Promise.all(
+      params.ids.map((id) =>
+        httpClient(`${apiUrl}/${resource}/${id}`, {
+          method: 'DELETE',
+        }),
+      ),
+    ).then((responses) => ({ data: responses.map(({ json }) => json) })),
+});


### PR DESCRIPTION
After https://github.com/marmelab/react-admin/pull/3726 (which is landed in react-admin 3.0), DataProviders are supposed to be an object now. They are easier to extend in the user's application and also give more useful Typescript types information (see https://github.com/marmelab/react-admin/issues/3686).
Btw, converting this module to Typescript is another thing that would be nice to have. In my project, I've just cloned this code and converted to Typescript already. But not sure how to publish it here, since it would be a whole lot of changes. Also, I wonder, is this module maintained at all?